### PR TITLE
Move all datastore calls to model/methods.js

### DIFF
--- a/crabfit-backend/index.js
+++ b/crabfit-backend/index.js
@@ -1,5 +1,4 @@
 import { config } from 'dotenv'
-import { Datastore } from '@google-cloud/datastore'
 import express from 'express'
 import cors from 'cors'
 
@@ -25,20 +24,7 @@ const corsOptions = {
   origin: process.env.NODE_ENV === 'production' ? 'https://crab.fit' : 'http://localhost:5173',
 }
 
-const datastore = new Datastore({
-  keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
-})
-
 app.use(express.json())
-app.use((req, _res, next) => {
-  req.datastore = datastore
-  req.types = {
-    event: process.env.NODE_ENV === 'production' ? 'Event' : 'DevEvent',
-    person: process.env.NODE_ENV === 'production' ? 'Person' : 'DevPerson',
-    stats: process.env.NODE_ENV === 'production' ? 'Stats' : 'DevStats',
-  }
-  next()
-})
 app.options('*', cors(corsOptions))
 app.use(cors(corsOptions))
 

--- a/crabfit-backend/model/methods.js
+++ b/crabfit-backend/model/methods.js
@@ -1,0 +1,126 @@
+import { Datastore } from '@google-cloud/datastore'
+
+const TYPES = {
+  event: process.env.NODE_ENV === 'production' ? 'Event' : 'DevEvent',
+  person: process.env.NODE_ENV === 'production' ? 'Person' : 'DevPerson',
+  stats: process.env.NODE_ENV === 'production' ? 'Stats' : 'DevStats',
+}
+
+const datastore = new Datastore({
+  keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+})
+
+export async function findEvent(eventId) {
+  const query = datastore.createQuery(TYPES.event)
+    .select('__key__')
+    .filter('__key__', datastore.key([TYPES.event, eventId]))
+
+  return (await datastore.runQuery(query))[0][0]
+}
+
+export async function findOldPeople(threeMonthsAgo) {
+  const peopleQuery = datastore.createQuery(TYPES.person).filter('created', '<', threeMonthsAgo)
+  const oldPeople = (await datastore.runQuery(peopleQuery))[0]
+  return oldPeople
+}
+
+export async function findOldEvents(threeMonthsAgo) {
+  const eventQuery = datastore.createQuery(TYPES.event).filter('visited', '<', threeMonthsAgo)
+  const oldEvents = (await datastore.runQuery(eventQuery))[0]
+  return oldEvents
+}
+
+export async function findPeopleOfEvent(eventId) {
+  const query = datastore.createQuery(TYPES.person).filter('eventId', eventId)
+  let people = (await datastore.runQuery(query))[0]
+  return people
+}
+
+export async function loadEvent(eventId) {
+  return (await datastore.get(datastore.key([TYPES.event, eventId])))[0]
+}
+
+export async function loadPerson(eventId, personName) {
+  const query = datastore.createQuery(TYPES.person)
+    .filter('eventId', eventId)
+    .filter('name', personName)
+
+  return (await datastore.runQuery(query))[0][0]
+}
+
+export async function loadStats(statName) {
+  return (await datastore.get(datastore.key([TYPES.stats, statName])))[0] || null
+}
+
+export async function storeEvent(eventId, name, currentTime, event) {
+  const entity = {
+    key: datastore.key([TYPES.event, eventId]),
+    data: {
+      name: name,
+      created: currentTime,
+      times: event.times,
+      timezone: event.timezone,
+    },
+  }
+
+  await datastore.insert(entity)
+}
+
+export async function storePerson(person, hash, eventId, currentTime) {
+  const entity = {
+    key: datastore.key(TYPES.person),
+    data: {
+      name: person.name.trim(),
+      password: hash,
+      eventId: eventId,
+      created: currentTime,
+      availability: [],
+    },
+  }
+
+  await datastore.insert(entity)
+}
+
+export async function storeStats(statName, value) {
+  await datastore.insert({
+    key: datastore.key([TYPES.stats, statName]),
+    data: { value },
+  })
+}
+
+export async function upsertEvent(entity, visited) {
+  await datastore.upsert({
+    ...entity,
+    visited: visited
+  })
+}
+
+export async function upsertPerson(entity, availability) {
+  await datastore.upsert({
+    ...entity,
+    availability: availability
+  })
+}
+
+export async function upsertStats(entity, value) {
+  await datastore.upsert({
+    ...entity,
+    value: value,
+  })
+}
+
+export async function deleteEvents(events) {
+  await datastore.delete(events.map(event => event[datastore.KEY]))
+}
+
+export async function deletePeople(people) {
+  await datastore.delete(people.map(person => person[datastore.KEY]))
+}
+
+export async function deletePerson(person) {
+  await datastore.delete(person[datastore.KEY])
+}
+
+export function getEventIds(events) {
+  return events.map(e => e[datastore.KEY].name)
+}

--- a/crabfit-backend/routes/getEvent.js
+++ b/crabfit-backend/routes/getEvent.js
@@ -1,10 +1,11 @@
 import dayjs from 'dayjs'
+import { loadEvent, upsertEvent } from '../model/methods'
 
 const getEvent = async (req, res) => {
   const { eventId } = req.params
 
   try {
-    const event = (await req.datastore.get(req.datastore.key([req.types.event, eventId])))[0]
+    const event = await loadEvent(eventId)
 
     if (event) {
       res.send({
@@ -13,10 +14,7 @@ const getEvent = async (req, res) => {
       })
 
       // Update last visited time
-      await req.datastore.upsert({
-        ...event,
-        visited: dayjs().unix()
-      })
+      await upsertEvent(event, dayjs().unix())
     } else {
       res.status(404).send({ error: 'Event not found' })
     }

--- a/crabfit-backend/routes/getPeople.js
+++ b/crabfit-backend/routes/getPeople.js
@@ -1,9 +1,10 @@
+import { findPeopleOfEvent } from "../model/methods"
+
 const getPeople = async (req, res) => {
   const { eventId } = req.params
 
   try {
-    const query = req.datastore.createQuery(req.types.person).filter('eventId', eventId)
-    let people = (await req.datastore.runQuery(query))[0]
+    let people = await findPeopleOfEvent(eventId)
     people = people.map(person => ({
       name: person.name,
       availability: person.availability,

--- a/crabfit-backend/routes/login.js
+++ b/crabfit-backend/routes/login.js
@@ -1,14 +1,12 @@
 import bcrypt from 'bcrypt'
+import { loadPerson } from '../model/methods'
 
 const login = async (req, res) => {
   const { eventId, personName } = req.params
   const { person } = req.body
 
   try {
-    const query = req.datastore.createQuery(req.types.person)
-      .filter('eventId', eventId)
-      .filter('name', personName)
-    const personResult = (await req.datastore.runQuery(query))[0][0]
+    const personResult = await loadPerson(eventId, personName)
 
     if (personResult) {
       if (personResult.password) {

--- a/crabfit-backend/routes/stats.js
+++ b/crabfit-backend/routes/stats.js
@@ -1,3 +1,4 @@
+import { loadStats } from '../model/methods'
 import packageJson from '../package.json'
 
 const stats = async (req, res) => {
@@ -5,8 +6,8 @@ const stats = async (req, res) => {
   let personCount = null
 
   try {
-    const eventResult = (await req.datastore.get(req.datastore.key([req.types.stats, 'eventCount'])))[0] || null
-    const personResult = (await req.datastore.get(req.datastore.key([req.types.stats, 'personCount'])))[0] || null
+    const eventResult = await loadStats('eventCount')
+    const personResult = await loadStats('personCount')
 
     if (eventResult) {
       eventCount = eventResult.value

--- a/crabfit-backend/routes/updatePerson.js
+++ b/crabfit-backend/routes/updatePerson.js
@@ -1,14 +1,13 @@
 import bcrypt from 'bcrypt'
 
+import { loadPerson, upsertPerson } from '../model/methods'
+
 const updatePerson = async (req, res) => {
   const { eventId, personName } = req.params
   const { person } = req.body
 
   try {
-    const query = req.datastore.createQuery(req.types.person)
-      .filter('eventId', eventId)
-      .filter('name', personName)
-    const personResult = (await req.datastore.runQuery(query))[0][0]
+    const personResult = await loadPerson(eventId, personName)
 
     if (personResult) {
       if (person && person.availability) {
@@ -19,10 +18,7 @@ const updatePerson = async (req, res) => {
           }
         }
 
-        await req.datastore.upsert({
-          ...personResult,
-          availability: person.availability,
-        })
+        await upsertPerson(personResult, person.availability)
 
         res.status(200).send({ success: 'Updated' })
       } else {


### PR DESCRIPTION
This PR moves all calls to the datastore library to a separate file, `model/methods.js`.

I am not quite sure if this PR should be merged at all: It doesn't really add anything of value by itself, only makes way for further refactoring, which will probably even delete `model/methods.js`.

But: I do somewhat like the fact that this is an intermediate step between a full-featured new abstraction layer (as I want to introduce in #231) and what we currently have. It feels easier to grasp (at least to me) and is maybe easier to review.

Maybe I will split the final code suggestion into several PRs: One that introduces the abstract base classes, this one, and one that moves all the methods into concrete implementations of the abstract base classes. This should hopefully reduce the cognitive load on review.