### PR TITLE
Show warning when selected dates are in the past

### DIFF
--- a/frontend/src/components/CalendarField/components/Month/Month.module.scss
+++ b/frontend/src/components/CalendarField/components/Month/Month.module.scss
@@ -91,3 +91,12 @@
     color: rgba(255,255,255,.5);
   }
 }
+
+.warningLabel {
+  display: flex;
+  padding-block: 0.9em;
+  gap: 0.5em;
+  align-items: center;
+  opacity: .75;
+  font-size: .9em;
+}

--- a/frontend/src/components/CalendarField/components/Month/Month.tsx
+++ b/frontend/src/components/CalendarField/components/Month/Month.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { rotateArray } from '@giraugh/tools'
 import { Temporal } from '@js-temporal/polyfill'
-import { AlertTriangle, AlertTriangleIcon, ChevronLeft, ChevronRight, FileWarningIcon } from 'lucide-react'
+import { AlertTriangle, ChevronLeft, ChevronRight } from 'lucide-react'
 
 import Button from '/src/components/Button/Button'
 import { useTranslation } from '/src/i18n/client'

--- a/frontend/src/components/CalendarField/components/Month/Month.tsx
+++ b/frontend/src/components/CalendarField/components/Month/Month.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { rotateArray } from '@giraugh/tools'
 import { Temporal } from '@js-temporal/polyfill'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { AlertTriangle, AlertTriangleIcon, ChevronLeft, ChevronRight, FileWarningIcon } from 'lucide-react'
 
 import Button from '/src/components/Button/Button'
 import { useTranslation } from '/src/i18n/client'
@@ -22,7 +22,8 @@ const Month = ({ value, onChange }: MonthProps) => {
 
   const weekStart = useStore(useSettingsStore, state => state.weekStart) ?? 0
 
-  const [page, setPage] = useState<Temporal.PlainYearMonth>(Temporal.Now.plainDateISO().toPlainYearMonth())
+  const now = useMemo(() => Temporal.Now.plainDateISO(), [])
+  const [page, setPage] = useState<Temporal.PlainYearMonth>(now.toPlainYearMonth())
   const dates = useMemo(() => calculateMonth(page, weekStart, i18n.language), [page, weekStart, i18n.language])
 
   // Ref and state required to rerender but also access static version in callbacks
@@ -35,6 +36,12 @@ const Month = ({ value, onChange }: MonthProps) => {
 
   const startPos = useRef({ x: 0, y: 0 })
   const mode = useRef<'add' | 'remove'>()
+
+  // Is 1 or more of the selected dates in the past?
+  const hasPastDates = useMemo(() => value
+    .some(plainDate => Temporal.PlainDate.compare(
+      now, Temporal.PlainDate.from(plainDate)
+    ) > 0), [value])
 
   const handleFinishSelection = useCallback(() => {
     if (mode.current === 'add') {
@@ -112,6 +119,11 @@ const Month = ({ value, onChange }: MonthProps) => {
         >{date.label}</button>)
       )}
     </div>
+
+    {hasPastDates && <div className={styles.warningLabel}>
+      <AlertTriangle size='1.2em' />
+      <span>{t('form.dates.warnings.date_in_past')}</span>
+    </div>}
   </>
 }
 

--- a/frontend/src/i18n/locales/en-GB/home.json
+++ b/frontend/src/i18n/locales/en-GB/home.json
@@ -21,7 +21,6 @@
       "warnings": {
         "date_in_past": "Some of the dates you've selected are in the past"
       }
-
     },
     "times": {
       "label": "What times might work?",

--- a/frontend/src/i18n/locales/en-GB/home.json
+++ b/frontend/src/i18n/locales/en-GB/home.json
@@ -17,7 +17,11 @@
         "previous": "Previous month",
         "next": "Next month",
         "today": "today"
+      },
+      "warnings": {
+        "date_in_past": "Some of the dates you've selected are in the past"
       }
+
     },
     "times": {
       "label": "What times might work?",

--- a/frontend/src/i18n/locales/en/home.json
+++ b/frontend/src/i18n/locales/en/home.json
@@ -17,6 +17,9 @@
         "previous": "Previous month",
         "next": "Next month",
         "today": "today"
+      },
+      "warnings": {
+        "date_in_past": "Some of the dates you've selected are in the past"
       }
     },
     "times": {


### PR DESCRIPTION
Closes #141

## Completed
- CalendarField.Month renders a small label below the calendar month field when the selected dates include a date in the past.
- Added a new localisation string at `home.form.dates.warnings.date_in_past`
  - Added string to `en` and `en-GB` locales

## Screenshot
<img width="674" alt="image" src="https://github.com/GRA0007/crab.fit/assets/16392483/1c1ccc3c-44a4-46ed-ba8d-a639de46bad2">

