### PR TITLE
Prevent colour index from escaping the bounds of the palette

### DIFF
--- a/frontend/src/components/AvailabilityViewer/AvailabilityViewer.tsx
+++ b/frontend/src/components/AvailabilityViewer/AvailabilityViewer.tsx
@@ -74,7 +74,7 @@ const AvailabilityViewer = ({ times, people, table }: AvailabilityViewerProps) =
           if (tempFocus) {
             peopleHere = peopleHere.filter(p => p === tempFocus)
           }
-          const color = palette[tempFocus && peopleHere.length ? max : peopleHere.length - min]
+          const color = palette[(tempFocus && peopleHere.length) ? Math.min(max, palette.length - 1) : Math.max(peopleHere.length - min, 0)]
 
           return <div
             key={y}


### PR DESCRIPTION
Closes #270 

If the min and max calculated for availabilities were not 0 and the amount of people, an incorrect index for the palette would be used, causing the page to crash. I've capped the index to the bounds of the palette so this can no longer happen.

<img width="440" alt="image" src="https://github.com/GRA0007/crab.fit/assets/8862273/342f44d6-1bbc-498d-b96d-22968f6633e7">