### PR TITLE
Added the feature to copy the list of available people to the Clipboard

### DIFF
--- a/frontend/src/components/AvailabilityViewer/AvailabilityViewer.tsx
+++ b/frontend/src/components/AvailabilityViewer/AvailabilityViewer.tsx
@@ -101,7 +101,18 @@ const AvailabilityViewer = ({ times, people, table }: AvailabilityViewerProps) =
                 people: peopleHere,
               })
             }}
+            onMouseDown={e => {
+              setTooltip({
+                anchor: e.currentTarget,
+                available: `${peopleHere.length} / ${filteredPeople.length} ${t('available')}`,
+                date: cell.label,
+                people: peopleHere,
+              })
+              let text2Clipboard = t("copy.message") + cell.label + ":\n" + peopleHere.join(';\n') + ";";
+              navigator.clipboard.writeText(text2Clipboard);
+            }}
             onMouseLeave={() => setTooltip(undefined)}
+            
           />
         })}
       </div>
@@ -130,7 +141,7 @@ const AvailabilityViewer = ({ times, people, table }: AvailabilityViewerProps) =
       />
 
       <span className={styles.info}>{t('group.info1')}</span>
-
+      <span className={styles.info}>{t('group.info3')}</span>
       {people.length > 1 && <>
         <span className={styles.info}>{t('group.info2')}</span>
         <div className={styles.people}>

--- a/frontend/src/i18n/locales/en-GB/event.json
+++ b/frontend/src/i18n/locales/en-GB/event.json
@@ -49,7 +49,13 @@
   "group": {
     "legend_tooltip": "Click to highlight highest availability",
     "info1": "Hover or tap the calendar below to see who is available",
-    "info2": "Click the names below to view people individually"
+    "info2": "Click the names below to view people individually",
+    "info3": "Click on a time slot to copy a list of people who are available then"
+  },
+
+  "copy": {
+    "alert": "List of available people copied to clipboard!",
+    "message": "List of available people at "
   },
 
   "you": {

--- a/frontend/src/i18n/locales/en/event.json
+++ b/frontend/src/i18n/locales/en/event.json
@@ -49,7 +49,14 @@
   "group": {
     "legend_tooltip": "Click to highlight highest availability",
     "info1": "Hover or tap the calendar below to see who is available",
-    "info2": "Click the names below to view people individually"
+    "info2": "Click the names below to view people individually",
+    "info3": "Click on a time slot to copy a list of people who are available then"
+    
+  },
+
+  "copy": {
+    "alert": "List of available people copied to clipboard!",
+    "message": "List of available people at "
   },
 
   "you": {

--- a/frontend/src/i18n/locales/pt-BR/event.json
+++ b/frontend/src/i18n/locales/pt-BR/event.json
@@ -49,7 +49,13 @@
   "group": {
     "legend_tooltip": "Clique para destacar o melhor tempo",
     "info1": "Passe o mouse ou toque o calendário pra ver quem está livre",
-    "info2": "Clique nos nomes pra ver a disponibilidade de cada um"
+    "info2": "Clique nos nomes pra ver a disponibilidade de cada um",
+    "info3": "Clica num slot para copiar uma lista das pessoas disponíveis nesse horário"
+  },
+  
+  "copy": {
+    "alert": "Lista de pessoas disponíveis copiada!",
+    "message": "Pessoas diponíveis a "
   },
 
   "you": {

--- a/frontend/src/i18n/locales/pt-PT/event.json
+++ b/frontend/src/i18n/locales/pt-PT/event.json
@@ -49,7 +49,12 @@
   "group": {
     "legend_tooltip": "Clica para realçar as horas com maior disponibilidade",
     "info1": "Passa o cursor ou clica no calendário abaixo para ver quem está disponível",
-    "info2": "Clica nos nomes abaixo para ver a disponibilidade de cada pessoa"
+    "info2": "Clica nos nomes abaixo para ver a disponibilidade de cada pessoa",
+    "info3": "Clica num slot para copiar uma lista das pessoas disponíveis nesse horário"
+  },
+  "copy": {
+    "alert": "Lista de pessoas disponíveis copiada!",
+    "message": "Pessoas diponíveis a "
   },
 
   "you": {


### PR DESCRIPTION
<!--
Thanks for taking the time to create a pull request on Crab Fit!
If you haven't already, please make sure you read the wiki page on pull requests before submitting this one: https://github.com/GRA0007/crab.fit/wiki/Pull-Requests

Don't forget to mention the issue this PR will close, e.g. Closes #123

If applicable, please also attach screenshots to this PR
-->

Allows the user to click a specific cell and it copies the available people for that time cell to the clipboard.

The copied text follows this example:
>List of available people on June 6, 2023 at 11:00 AM:
Midas;
mike;
Test;



