### PR TITLE
Fix missing days 

### DIFF
--- a/frontend/src/utils/calculateColumns.ts
+++ b/frontend/src/utils/calculateColumns.ts
@@ -7,10 +7,10 @@ import { Temporal } from '@js-temporal/polyfill'
  */
 export const calculateColumns = (dates: Temporal.ZonedDateTime[]): (Temporal.PlainDate | null)[] => {
   // Dedupe dates by date and sort
-  const sortedDates = [...new Map(dates.map(d => {
+  const sortedDates = Array.from(new Map(dates.map(d => {
     const plain = d.toPlainDate()
     return [plain.toString(), plain]
-  })).values()]
+  })).values())
     .sort(Temporal.PlainDate.compare)
 
   // Partition by distance

--- a/frontend/src/utils/convertTimesToDates.ts
+++ b/frontend/src/utils/convertTimesToDates.ts
@@ -8,9 +8,11 @@ import { Temporal } from '@js-temporal/polyfill'
 export const convertTimesToDates = (times: string[], timezone: string): Temporal.ZonedDateTime[] => {
   const isSpecificDates = times[0].length === 13
 
+  console.log(times)
+
   return times.map(time => isSpecificDates ?
     parseSpecificDate(time).withTimeZone(timezone)
-    : parseWeekdayDate(time).withTimeZone(timezone)
+    : parseWeekdayDate(time, timezone).withTimeZone(timezone)
   )
 }
 
@@ -32,7 +34,7 @@ export const parseSpecificDate = (str: string): Temporal.ZonedDateTime => {
 }
 
 // Parse from UTC `HHmm-d` format into a ZonedDateTime in UTC based on the current date
-const parseWeekdayDate = (str: string): Temporal.ZonedDateTime => {
+const parseWeekdayDate = (str: string, timezone: string): Temporal.ZonedDateTime => {
   if (str.length !== 6) {
     throw new Error('String must be in HHmm-d format')
   }
@@ -41,14 +43,25 @@ const parseWeekdayDate = (str: string): Temporal.ZonedDateTime => {
   const [hour, minute] = [Number(str.substring(0, 2)), Number(str.substring(2, 4))]
   let dayOfWeek = Number(str.substring(5))
   if (dayOfWeek === 0) {
-    dayOfWeek = 7 // Sunday is 7 in ISO8601
+     dayOfWeek = 7 // Sunday is 7 in ISO8601
   }
 
   // Construct PlainDateTime from today
-  const today = Temporal.Now.zonedDateTimeISO('UTC').round('day')
-  const currentDayOfWeek = today.dayOfWeek
-  return today.with({
-    hour, minute,
-    day: today.day + (dayOfWeek - currentDayOfWeek), // Set day of week
+  const today = Temporal.Now.zonedDateTimeISO('Utc').round('day')
+  const dayDelta = dayOfWeek - today.dayOfWeek
+  const resultDay = today.add({ days: dayDelta })
+
+  let resultDate = resultDay.with({
+    hour, minute
   })
+
+  // If resulting day (in target timezone) is in the next week, move it back to this week
+  // TODO: change data representation instead
+  const dayInTz = resultDate.withTimeZone(timezone)
+  const todayInTz = today.withTimeZone(timezone)
+  if (dayInTz.weekOfYear > todayInTz.weekOfYear) {
+    resultDate = resultDate.subtract({ days: 7 })
+  }
+
+  return resultDate
 }

--- a/frontend/src/utils/convertTimesToDates.ts
+++ b/frontend/src/utils/convertTimesToDates.ts
@@ -8,8 +8,6 @@ import { Temporal } from '@js-temporal/polyfill'
 export const convertTimesToDates = (times: string[], timezone: string): Temporal.ZonedDateTime[] => {
   const isSpecificDates = times[0].length === 13
 
-  console.log(times)
-
   return times.map(time => isSpecificDates ?
     parseSpecificDate(time).withTimeZone(timezone)
     : parseWeekdayDate(time, timezone).withTimeZone(timezone)
@@ -43,11 +41,11 @@ const parseWeekdayDate = (str: string, timezone: string): Temporal.ZonedDateTime
   const [hour, minute] = [Number(str.substring(0, 2)), Number(str.substring(2, 4))]
   let dayOfWeek = Number(str.substring(5))
   if (dayOfWeek === 0) {
-     dayOfWeek = 7 // Sunday is 7 in ISO8601
+    dayOfWeek = 7 // Sunday is 7 in ISO8601
   }
 
   // Construct PlainDateTime from today
-  const today = Temporal.Now.zonedDateTimeISO('Utc').round('day')
+  const today = Temporal.Now.zonedDateTimeISO('UTC').round('day')
   const dayDelta = dayOfWeek - today.dayOfWeek
   const resultDay = today.add({ days: dayDelta })
 


### PR DESCRIPTION
Fixes #299

## Completed
- Change the weekday parsing to use date arithmetic rather than setting the date directly
  - This causes the month to transparently wrap to the prior/next.
- Fix issue with duplicated weekdays