### PR TITLE
Set colormap bounds to data range for better contrast

### DIFF
--- a/frontend/src/utils/calculateAvailability.ts
+++ b/frontend/src/utils/calculateAvailability.ts
@@ -23,8 +23,8 @@ interface AvailabilityInfo {
  * group availability for each date passed in.
  */
 export const calculateAvailability = (dates: string[], people: Person[]): AvailabilityInfo => {
-  let min = 0
-  let max = people.length
+  let min = people.length
+  let max = 0
 
   const availabilities: Availability[] = dates.map(date => {
     const names = people.flatMap(p => p.availability.some(d => d === date) ? [p.name] : [])


### PR DESCRIPTION
Closes #311 by scaling the colormap to the range of the data, improving contrast.

# Pros and Cons of Current Behavior

With the range of the data set to [0, num people] there is low color contrast when there is less difference in availability between possible meeting times. E.g. if for all times only about half of people are available, the colors will all be close to the center of the colormap's full range.

A pro of this behavior is that it makes it obvious if there is low consensus about the best times.

However, since the goal of crab.fit is to help people decide on the best time, that should probably be the priority. Scaling the colormap to the range of the data makes this easier.

# Screenshots

At the worst times, 2/9 people are available. At best it's 5/9. Without scaling the colormap to match the data it's difficult to see the difference between the times.

Before:
<img width="660" alt="crabfit_low_contrast" src="https://github.com/GRA0007/crab.fit/assets/143457426/c665576d-9ee7-4926-860a-a9a0680ff1ce">

After:
<img width="660" alt="crabfit_higher_contrast" src="https://github.com/GRA0007/crab.fit/assets/143457426/5c82fd63-d7a1-481d-a981-f5ce23bdcf44">
