### PR TITLE
Pin images to bookworm and install openssl

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 # This dockerfile builds the API and runs it on a minimal container with the Datastore adaptor
 
-FROM rust:latest as builder
+FROM rust:bookworm as builder
 
 # Install CA Certs for Hyper
 RUN apt-get install -y --no-install-recommends ca-certificates
@@ -14,7 +14,9 @@ RUN --mount=type=cache,target=/usr/local/cargo,from=rust:latest,source=/usr/loca
     cargo build --release --features datastore-adaptor && mv ./target/release/crabfit-api ./api
 
 # Runtime image
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
+
+RUN apt-get update; apt-get install -y openssl
 
 # Run as "app" user
 RUN useradd -ms /bin/bash app


### PR DESCRIPTION
<!--
Thanks for taking the time to create a pull request on Crab Fit!
If you haven't already, please make sure you read the wiki page on pull requests before submitting this one: https://github.com/GRA0007/crab.fit/wiki/Pull-Requests

Don't forget to mention the issue this PR will close, e.g. Closes #123

If applicable, please also attach screenshots to this PR
-->
Closes #315 

The runtime image for the API needs libssl to work. It looks like a version skew between the build and runtime images was causing the wrong version of libssl to be available, and the container wouldn't run. So, this PR...

- Pins builder to `rust:bookworm` (latest at time of PR)
- Pins runtime to `debian:bookworm-slim` (latest at time of PR)
- Installs openssl package in runtime image to satisfy libssl dependency

Updating the base image to the latest Debian ought to be a discrete decision to make, instead of being at the whims and mercy of `latest` 🙃 .