### PR TITLE
Add environment variable to change the share URL of self-hosted instances

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_API_URL="http://127.0.0.1:3000"
+NEXT_PUBLIC_DOMAIN_FRONT="crab.fit"
 
 # Google auth for calendar syncing, feature will be disabled if these aren't set
 # NEXT_PUBLIC_GOOGLE_CLIENT_ID=""

--- a/frontend/src/app/[id]/page.tsx
+++ b/frontend/src/app/[id]/page.tsx
@@ -13,6 +13,11 @@ import { makeClass, relativeTimeFormat } from '/src/utils'
 import EventAvailabilities from './EventAvailabilities'
 import styles from './page.module.scss'
 
+if (process.env.NEXT_PUBLIC_DOMAIN_FRONT === undefined) {
+  throw new Error('Expected front domain name environment variable')
+}
+const DOMAIN_FRONT = process.env.NEXT_PUBLIC_DOMAIN_FRONT
+
 interface PageProps {
   params: { id: string }
 }
@@ -49,10 +54,10 @@ const Page = async ({ params }: PageProps) => {
         >{t('common:created', { date: relativeTimeFormat(Temporal.Instant.fromEpochSeconds(event.created_at), i18n.language) })}</span>
 
         <Copyable className={styles.info}>
-          {`https://crab.fit/${event.id}`}
+          {`https://${DOMAIN_FRONT}/${event.id}`}
         </Copyable>
         <p className={makeClass(styles.info, styles.noPrint)}>
-          <Trans i18nKey="event:nav.shareinfo" t={t} i18n={i18n}>_<a href={`mailto:?subject=${encodeURIComponent(t('event:nav.email_subject', { event_name: event.name }))}&body=${encodeURIComponent(`${t('event:nav.email_body')} https://crab.fit/${event.id}`)}`}>_</a>_</Trans>
+          <Trans i18nKey="event:nav.shareinfo" t={t} i18n={i18n}>_<a href={`mailto:?subject=${encodeURIComponent(t('event:nav.email_subject', { event_name: event.name }))}&body=${encodeURIComponent(`${t('event:nav.email_body')} https://${DOMAIN_FRONT}/${event.id}`)}`}>_</a>_</Trans>
         </p>
       </Content>
     </Suspense>

--- a/frontend/src/components/CreateForm/components/EventInfo/EventInfo.tsx
+++ b/frontend/src/components/CreateForm/components/EventInfo/EventInfo.tsx
@@ -6,6 +6,11 @@ import { useTranslation } from '/src/i18n/client'
 
 import styles from './EventInfo.module.scss'
 
+if (process.env.NEXT_PUBLIC_DOMAIN_FRONT === undefined) {
+  throw new Error('Expected front domain name environment variable')
+}
+const DOMAIN_FRONT = process.env.NEXT_PUBLIC_DOMAIN_FRONT
+
 interface EventInfoProps {
   event: EventResponse
 }
@@ -16,10 +21,10 @@ const EventInfo = ({ event }: EventInfoProps) => {
   return <div className={styles.wrapper}>
     <h2>{event.name}</h2>
     <Copyable className={styles.info}>
-      {`https://crab.fit/${event.id}`}
+      {`https://${DOMAIN_FRONT}/${event.id}`}
     </Copyable>
     <p className={styles.info}>
-      <Trans i18nKey="event:nav.shareinfo_alt" t={t} i18n={i18n}>_<a href={`mailto:?subject=${encodeURIComponent(t('nav.email_subject', { event_name: event.name }))}&body=${encodeURIComponent(`${t('nav.email_body')} https://crab.fit/${event.id}`)}`} target="_blank">_</a>_</Trans>
+      <Trans i18nKey="event:nav.shareinfo_alt" t={t} i18n={i18n}>_<a href={`mailto:?subject=${encodeURIComponent(t('nav.email_subject', { event_name: event.name }))}&body=${encodeURIComponent(`${t('nav.email_body')} https://${DOMAIN_FRONT}/${event.id}`)}`} target="_blank">_</a>_</Trans>
     </p>
   </div>
 }


### PR DESCRIPTION
Fixes #297 with:

- A new environment variable `NEXT_PUBLIC_DOMAIN_FRONT` set to a default value of `crab.fit` to keep backwards compatibility
- Two hard-coded `crab.fit` URLs changed with the new env in pages and eventinfos

Tested and functional

----------

PS: I love your software and FYI, I packaged it for two contexts:

- Yunohost, a self-hosting framework used by hundreds of people. It basically is a bunch a bash scripts to install/configure/uninstall: [https://github.com/YunoHost-Apps/crabfit_ynh](https://github.com/YunoHost-Apps/crabfit_ynh)
  - This PR actually originates from a patch there
- Picasoft, a french NGO providing FOSS services to university students. It creates two docker images and integrates them in traefik : [https://gitlab.utc.fr/picasoft/projets/services/crabfit](https://gitlab.utc.fr/picasoft/projets/services/crabfit)

Cheers!